### PR TITLE
Using less's relativeUrls-option instead of manipulating the fileInfo directly

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,8 @@ module.exports = function(input) {
 					errored = true;
 					return;
 				}
-				updateFileInfo(newFileInfo, rootContext, filename);
+				newFileInfo.filename = filename;
+				newFileInfo.currentDirectory = path.dirname(filename);
 				// The default (asynchron)
 				loaderContext.loadModule("-!" + __dirname + "/stringify.loader.js!" + filename, function(err, data) {
 					if(err) {
@@ -47,7 +48,8 @@ module.exports = function(input) {
 		} else {
 			var filename = loaderContext.resolveSync(context, moduleName);
 			loaderContext.dependency && loaderContext.dependency(filename);
-			updateFileInfo(newFileInfo, rootContext, filename);
+			newFileInfo.filename = filename;
+			newFileInfo.currentDirectory = path.dirname(filename);
 			// Make it synchron
 			try {
 				var data = fs.readFileSync(filename, 'utf-8');
@@ -66,6 +68,8 @@ module.exports = function(input) {
 	less.render(input, {
 		filename: this.resource,
 		paths: [],
+		rootpath: this.context,
+		relativeUrls: true,
 		compress: !!this.minimize
 	}, function(e, result) {
 		if(e) return resultcb(e);
@@ -77,13 +81,4 @@ function urlToRequire(url) {
 		return url.substring(1);
 	else
 		return "./"+url;
-}
-function updateFileInfo(fileInfo, rootContext, filename) {
-	fileInfo.filename = filename;
-	fileInfo.currentDirectory = path.dirname(filename);
-	fileInfo.rootpath = "./";
-	var relativePath = path.relative(rootContext, fileInfo.currentDirectory);
-	if(relativePath) {
-		fileInfo.rootpath += relativePath + "/";
-	}
 }


### PR DESCRIPTION
My solution introduced with ad8adde1c2acf69925f6f889cd4d38c62a7f173c is kind of a bit hacky, because the `fileInfo`-object is manipulated directly.

Now I found out that less is providing a `relativeUrls`-option which is rewriting all referenced urls and imports. It's basically the same as before, but the "official" way :wink: 

Additionally this fixes a small bug on windows where urls starting with `../` where not correctly resolved.
