### PR TITLE
Bump less version

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "node node_modules/mocha/bin/mocha -R spec"
   },
   "peerDependencies": {
-    "less": "^1.5"
+    "less": "^1.5 || ^2.0.0"
   },
   "devDependencies": {
     "should": "^3.3.1",


### PR DESCRIPTION
Currently, if you have `less v2.x` installed in your project, `npm install less-loader` fails with the error:

```
npm ERR! peerinvalid The package less does not satisfy its siblings'
peerDependencies requirements!
```

This patch should fix it.
