### PR TITLE
feat：support set compress option by query

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,11 +20,13 @@ module.exports = function(source) {
 	var isSync = typeof cb !== "function";
 	var finalCb = cb || this.callback;
 	var configKey = query.config || "lessLoader";
+	var forceMinimize = query.minimize;
+	var minimize = typeof forceMinimize !== "undefined" ? !!forceMinimize : this.minimize;
 	var config = {
 		filename: this.resource,
 		paths: [],
 		relativeUrls: true,
-		compress: !!this.minimize
+		compress: minimize
 	};
 	var webpackPlugin = {
 		install: function(less, pluginManager) {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "less-loader",
-  "version": "2.2.3",
-  "author": "Tobias Koppers @sokra",
-  "description": "less loader module for webpack",
+  "name": "lessnew-loader",
+  "version": "1.0.0",
+  "author": "xiaoji121",
+  "description": "new less loader module for webpack",
   "scripts": {
     "test": "node --no-deprecation node_modules/.bin/_mocha -R spec",
     "test-source-map": "webpack --config test/sourceMap/webpack.config.js && open ./test/sourceMap/index.html"


### PR DESCRIPTION
in source code on this line:

https://github.com/webpack/less-loader/blob/master/index.js#L27

the less compress option which get from context is not enough,because of when the less-loader being used with other loader, but the loader will handle the comments, but the comments was removed by less-loader, this situation is so bad.

so i want to set the compress option enforced by query.

so i pull the follow pull request.

thank you !
