### PR TITLE
Instead of using key loaders in your config use key loader.

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,20 +134,20 @@ module.exports = {
     rules: [
       {
         test: /\.less$/,
-        use: ExtractTextPlugin.extract(
+        use: ExtractTextPlugin.extract({
           fallbackLoader: 'style-loader',
-          loaders: [
+          loader: [
             // activate source maps via loader query
             {
               loader: 'css-loader',
               options: { sourceMap: true, importLoaders: 1 }
-            }
+            },
             {
               loader: 'less-loader',
               options: { sourceMap: true }
             }
           ]
-        )
+        })
       }
     ]
   },


### PR DESCRIPTION
Instead of using key loaders in your config use key loader.
There is no option loaders in ExtractTextPlugin.