### PR TITLE
Add support for webpack2 loader options. Fixes #115. Fixes #128.

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,6 @@ module.exports = function(source) {
 	var cb = this.async();
 	var isSync = typeof cb !== "function";
 	var finalCb = cb || this.callback;
-	var configKey = query.config || "lessLoader";
 	var config = {
 		filename: this.resource,
 		paths: [],
@@ -47,14 +46,8 @@ module.exports = function(source) {
 	config.plugins.push(webpackPlugin);
 
 	// If present, add custom LESS plugins.
-	if (this.options[configKey]) {
-		config.plugins = config.plugins.concat(this.options[configKey].lessPlugins || []);
-	}
-
-	// Also support webpack 2 loader.options.
-	if (query.lessPlugins) {
-		config.plugins = config.plugins.concat(query.lessPlugins);
-	}
+	var customPlugins = loaderUtils.getLoaderConfig(this, "lessLoader").lessPlugins || [];
+	config.plugins = config.plugins.concat(customPlugins);
 
 	// not using the `this.sourceMap` flag because css source maps are different
 	// @see https://github.com/webpack/css-loader/pull/40

--- a/index.js
+++ b/index.js
@@ -51,6 +51,11 @@ module.exports = function(source) {
 		config.plugins = config.plugins.concat(this.options[configKey].lessPlugins || []);
 	}
 
+	// Also support webpack 2 loader.options.
+	if (query.lessPlugins) {
+		config.plugins = config.plugins.concat(query.lessPlugins);
+	}
+
 	// not using the `this.sourceMap` flag because css source maps are different
 	// @see https://github.com/webpack/css-loader/pull/40
 	if (query.sourceMap) {


### PR DESCRIPTION
No tests were added since it will require webpack2. However we can't still move to webpack2 since it is currently in beta.
Tested against initial tests and also locally against support for less-loader webpack2 options param.