### PR TITLE
Fix invalid syntax in code sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ module.exports = {
     rules: [
       {
         test: /\.less$/,
-        use: ExtractTextPlugin.extract(
+        use: ExtractTextPlugin.extract({
           fallbackLoader: 'style-loader',
           loaders: [
             // activate source maps via loader query
@@ -147,7 +147,7 @@ module.exports = {
               options: { sourceMap: true }
             }
           ]
-        )
+        })
       }
     ]
   },

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ module.exports = {
         test: /\.less$/,
         use: ExtractTextPlugin.extract({
           fallbackLoader: 'style-loader',
-          loaders: [
+          loader: [
             // activate source maps via loader query
             {
               loader: 'css-loader',

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ module.exports = {
         test: /\.less$/,
         use: ExtractTextPlugin.extract({
           fallbackLoader: 'style-loader',
-          loader: [
+          use: [
             // activate source maps via loader query
             {
               loader: 'css-loader',


### PR DESCRIPTION
The parameters for ExtractTextPlugin should be an object. It's invalid in it's current form.