### PR TITLE
less loader - rules -> loaders

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Use the loader either via your webpack config, CLI or inline.
 ```js
 module.exports = {
   module: {
-    rules: [
+    loaders: [
       {
         test: /\.less$/,
         use: [


### PR DESCRIPTION
In Webpack 2 it should be module.loaders instead of module.rules as far as i know.