### PR TITLE
fix the bug :  'Module not found: Error: Can't resolve 'less-loader'

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "4.0.0",
   "author": "Johannes Ewald @jhnns",
   "description": "Less loader for webpack. Compiles Less to CSS.",
-  "main": "dist/cjs.js",
+  "main": "dist/index.js",
   "scripts": {
     "create-spec": "babel-node test/helpers/createSpec.js",
     "pretest": "npm run create-spec",


### PR DESCRIPTION
fix the bug :  'Module not found: Error: Can't resolve 'less-loader'

<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->
