### PR TITLE
fix: sourcesContent missing in source maps

### DIFF
--- a/src/getOptions.js
+++ b/src/getOptions.js
@@ -24,6 +24,16 @@ function getOptions(loaderContext) {
     options.plugins.push(createWebpackLessPlugin(loaderContext));
   }
 
+  if (options.sourceMap) {
+    if (typeof options.sourceMap === 'boolean') {
+      options.sourceMap = {};
+    }
+    if ('outputSourceFiles' in options.sourceMap === false) {
+      // Include source files as `sourceContents` as sane default since this makes source maps "just work" in most cases
+      options.sourceMap.outputSourceFiles = true;
+    }
+  }
+
   return options;
 }
 

--- a/test/helpers/createSpec.js
+++ b/test/helpers/createSpec.js
@@ -28,6 +28,7 @@ const lessOptions = {
     '--source-map',
     `--source-map-basepath=${projectPath}`,
     `--source-map-rootpath=${projectPath}`,
+    '--source-map-less-inline',
   ],
   'import-paths': [
     `--include-path=${path.resolve(fixturesPath, 'node_modules')}`,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -165,7 +165,7 @@ test('should transform urls', async () => {
   await compileAndCompare('url-path');
 });
 
-test('should generate source maps', async () => {
+test('should generate source maps with sourcesContent by default', async () => {
   let inspect;
   const rules = moduleRules.basic({ sourceMap: true }, {}, (i) => {
     inspect = i;
@@ -177,8 +177,28 @@ test('should generate source maps', async () => {
   ]);
   const [actualCss, actualMap] = inspect.arguments;
 
+  expect(Array.isArray(actualMap.sourcesContent)).toBe(true);
+  expect(actualMap.sourcesContent.length).toBe(2);
+
+  // We can't actually compare the sourcesContent because it's slightly different because of our import rewriting
+  delete actualMap.sourcesContent;
+  delete expectedMap.sourcesContent;
+
   expect(actualCss).toEqual(expectedCss);
   expect(actualMap).toEqual(expectedMap);
+});
+
+test('should be possible to override sourceMap.outputSourceFiles', async () => {
+  let inspect;
+  const rules = moduleRules.basic({ sourceMap: { outputSourceFiles: false } }, {}, (i) => {
+    inspect = i;
+  });
+
+  await compile('source-map', rules);
+
+  const [actualMap] = inspect.arguments;
+
+  expect(actualMap).not.toHaveProperty('sourcesContent');
 });
 
 test('should install plugins', async () => {


### PR DESCRIPTION
less-loader 4 did not automatically apply the sourceMap.outputSourceFiles option anymore. This led to a situation where source maps didn't work out of the box anymore (while it still was possible to set this option manually).

Fixes #183

<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->
