### PR TITLE
docs(README): absolute link to example

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ module.exports = {
 };
 ```
 
-Also checkout the [sourceMaps example](/examples/sourceMaps).
+Also checkout the [sourceMaps example](https://github.com/webpack-contrib/less-loader/tree/master/examples/sourceMaps).
 
 If you want to edit the original Less files inside Chrome, [there's a good blog post](https://medium.com/@toolmantim/getting-started-with-css-sourcemaps-and-in-browser-sass-editing-b4daab987fb0). The blog post is about Sass but it also works for Less.
 


### PR DESCRIPTION
This is required for inclusion at https://webpack.js.org/loaders/less-loader/. Currently, the hyperlink CI check fails ([example](https://travis-ci.org/webpack/webpack.js.org/builds/228533163#L783)).