### PR TITLE
test(index): loaders fails on nested imports

### DIFF
--- a/test/fixtures/less/folder/nested.less
+++ b/test/fixtures/less/folder/nested.less
@@ -1,0 +1,3 @@
+.nested-import-css {
+    background: <%= color %>;
+}

--- a/test/fixtures/less/folder/nested.less
+++ b/test/fixtures/less/folder/nested.less
@@ -1,3 +1,3 @@
-.nested-import-css {
+.nested-import {
     background: <%= color %>;
 }

--- a/test/fixtures/less/import-nested.less
+++ b/test/fixtures/less/import-nested.less
@@ -1,0 +1,1 @@
+@import "folder/nested.less";

--- a/test/fixtures/less/import-nested.less
+++ b/test/fixtures/less/import-nested.less
@@ -1,1 +1,5 @@
+.top-import {
+    background: <%= color %>;
+}
+
 @import "folder/nested.less";

--- a/test/helpers/moduleRules.js
+++ b/test/helpers/moduleRules.js
@@ -1,6 +1,7 @@
 const lessLoader = require.resolve('../../src');
 const helperLoader = require.resolve('./helperLoader.js');
 const someFileLoader = require.resolve('./someFileLoader.js');
+const nestedFileLoader = require.resolve('./nestedFileLoader.js');
 
 function basic(lessLoaderOptions, lessLoaderContext = {}, inspectCallback = () => {}) {
   return [{
@@ -42,5 +43,24 @@ function nonLessImport(inspectCallback) {
   }];
 }
 
+function nestedImport(inspectCallback) {
+  return [{
+    test: /\.less$/,
+    loaders: [{
+      loader: helperLoader,
+    }, {
+      loader: 'inspect-loader',
+      options: {
+        callback: inspectCallback,
+      },
+    }, {
+      loader: lessLoader,
+    }, {
+      loader: nestedFileLoader,
+    }],
+  }];
+}
+
 exports.basic = basic;
 exports.nonLessImport = nonLessImport;
+exports.nestedImport = nestedImport;

--- a/test/helpers/nestedFileLoader.js
+++ b/test/helpers/nestedFileLoader.js
@@ -1,0 +1,5 @@
+function nestedFileLoader(source) {
+  return source.replace('<%= color %>', 'hotpink');
+}
+
+module.exports = nestedFileLoader;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -167,7 +167,7 @@ test('should run webpack loaders on nested imports', async () => {
 
   const [css] = inspect.arguments;
 
-  expect(css).toMatch(/\.nested-import-css {\s*background: hotpink;\s*}\s*/);
+  expect(css).toMatch(/\.top-import {\s*background: hotpink;\s*}\s*\.nested-import {\s*background: hotpink;\s*}\s*/);
 });
 
 test('should compile data-uri function', async () => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -157,6 +157,19 @@ test('should allow to import non-less files', async () => {
   expect(css).toMatch(/\.some-file {\s*background: hotpink;\s*}\s*/);
 });
 
+test('should run webpack loaders on nested imports', async () => {
+  let inspect;
+  const rules = moduleRules.nestedImport((i) => {
+    inspect = i;
+  });
+
+  await compile('import-nested', rules);
+
+  const [css] = inspect.arguments;
+
+  expect(css).toMatch(/\.nested-import-css {\s*background: hotpink;\s*}\s*/);
+});
+
 test('should compile data-uri function', async () => {
   await compileAndCompare('data-uri');
 });


### PR DESCRIPTION
**Just a Failing Test ATM**

This adds a failing test case that shows that the webpack loaders are not run on nested imports. I'm honestly not sure what the solution is but at least we have a test :smile:

The expected output of `import-nested.less` should be:

```css
.top-import {
      background: hotpink;
}
.nested-import {
      background: hotpink;
}
```

But, instead you get the following (because the loaders are not run on the nested import):

```css
.top-import {
      background: hotpink;
}
.nested-import {
      background: <%= color %>;
}
```