### PR TITLE
feat: support for receiving a `{Function}` (`options.modifyVars`)

### DIFF
--- a/src/getOptions.js
+++ b/src/getOptions.js
@@ -34,6 +34,10 @@ function getOptions(loaderContext) {
     }
   }
 
+  if (typeof options.modifyVars === 'function') {
+    options.modifyVars = options.modifyVars(loaderContext);
+  }
+
   return options;
 }
 

--- a/test/fixtures/less/options-modifyvars-function.less
+++ b/test/fixtures/less/options-modifyvars-function.less
@@ -1,0 +1,5 @@
+@color: #000;
+
+.box {
+    color: @color
+}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -286,14 +286,21 @@ test('should be able to import a file with an absolute path', async () => {
   expect(css).toEqual('.it-works {\n  color: yellow;\n}\n');
 });
 
-test('should support receiving a function for options modifyVars', async () => {
-  let res = false;
+test('should support receiving a function for options.modifyVars', async () => {
   const loaderOptions = {
     modifyVars: (loader) => {
-      res = typeof loader === 'object';
+      expect(loader).toBeInstanceOf(Object);
+      return { '@color': 'yellow' };
     },
   };
 
-  await compile('basic', moduleRules.basic(loaderOptions));
-  expect(res).toBe(true);
+  let inspect;
+  const rules = moduleRules.basic(loaderOptions, {}, (i) => {
+    inspect = i;
+  });
+
+  await compile('options-modifyvars-function', rules)
+      .catch(e => e);
+  const [css] = inspect.arguments;
+  expect(css).toEqual('.box {\n  color: yellow;\n}\n');
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -285,3 +285,15 @@ test('should be able to import a file with an absolute path', async () => {
   const [css] = inspect.arguments;
   expect(css).toEqual('.it-works {\n  color: yellow;\n}\n');
 });
+
+test('should support receiving a function for options modifyVars', async () => {
+  let res = false;
+  const loaderOptions = {
+    modifyVars: (loader) => {
+      res = typeof loader === 'object';
+    },
+  };
+
+  await compile('basic', moduleRules.basic(loaderOptions));
+  expect(res).toBe(true);
+});


### PR DESCRIPTION
<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->
