### PR TITLE
fix(getOptions): handle non-array values correctly (`options.plugins`)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "less-loader",
-  "version": "4.0.5",
+  "version": "4.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8053,14 +8053,14 @@
       "dev": true
     },
     "webpack": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.8.1.tgz",
-      "integrity": "sha512-5ZXLWWsMqHKFr5y0N3Eo5IIisxeEeRAajNq4mELb/WELOR7srdbQk2N5XiyNy2A/AgvlR3AmeBCZJW8lHrolbw==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.10.0.tgz",
+      "integrity": "sha512-fxxKXoicjdXNUMY7LIdY89tkJJJ0m1Oo8PQutZ5rLgWbV5QVKI15Cn7+/IHnRTd3vfKfiwBx6SBqlorAuNA8LA==",
       "dev": true,
       "requires": {
         "acorn": "5.2.1",
         "acorn-dynamic-import": "2.0.2",
-        "ajv": "5.3.0",
+        "ajv": "5.5.2",
         "ajv-keywords": "2.1.1",
         "async": "2.6.0",
         "enhanced-resolve": "3.4.1",
@@ -8083,9 +8083,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz",
-          "integrity": "sha1-RBT/dKUIecII7l/cgm4ywwNUnto=",
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
           "dev": true,
           "requires": {
             "co": "4.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "less-loader",
-  "version": "4.0.5",
+  "version": "4.0.6",
   "author": "Johannes Ewald @jhnns",
   "description": "Less loader for webpack. Compiles Less to CSS.",
   "main": "dist/cjs.js",

--- a/src/getOptions.js
+++ b/src/getOptions.js
@@ -18,6 +18,10 @@ function getOptions(loaderContext) {
   // We need to set the filename because otherwise our WebpackFileManager will receive an undefined path for the entry
   options.filename = loaderContext.resource;
 
+  if (typeof options.plugins === 'object' && !Array.isArray(options.plugins))  {
+    options.plugins = Object.entries(options.plugins).map(([_, plugin]) => plugin)
+  }
+
   // When no paths are given, we use the webpack resolver
   if ('paths' in options === false) {
     // It's safe to mutate the array now because it has already been cloned


### PR DESCRIPTION
I use nwb-less for less configure, I found options.plugin type is obejct, that not array, add type convert to fix this bug.