### PR TITLE
fix(package): add `webpack >= v4.0.0`  (`peerDependencies`)

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "peerDependencies": {
     "less": "^2.3.1",
-    "webpack": "^2.0.0 || ^3.0.0"
+    "webpack": "^2.0.0 || ^3.0.0 || ^4.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.24.0",


### PR DESCRIPTION
Adds webpack 4 as an allowed peer dependency

Had to fix the dev dependency of webpack to `^3.10.0` (matches uglify plugin) otherwise the tests would use latest and fail as `mode` was not set in the config.