### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This module requires a minimum of Node v6.9.0 and Webpack v4.0.0.
 To begin, you'll need to install `less-loader`:
 
 ```console
-$ npm install less-loader --save-dev
+$ npm install less less-loader --save-dev
 ```
 
 Then modify your `webpack.config.js`:


### PR DESCRIPTION
need to install less with less-loader together to avoid the error such as "ERROR in Cannot find module 'less'"

<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->
If following the guide to config less-loader with a webapck project, the error "ERROR in Cannot find module 'less'" will be thrown out when running build or starting up a dev-server. need to install less module together with less-loader. So the command line should be 
npm install less less-loader --save-dev
### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info
