### PR TITLE
Support Less 3 module imports

### DIFF
--- a/src/createWebpackLessPlugin.js
+++ b/src/createWebpackLessPlugin.js
@@ -68,6 +68,13 @@ function createWebpackLessPlugin(loaderContext) {
       let resolvedFilename;
 
       return resolve(context, moduleRequest)
+        .catch((e) => {
+          if (less.version[0] >= 3) {
+            // Try less 3 style import `import "package_name/file"`
+            return resolve(context, url);
+          }
+          throw e;
+        })
         .then((f) => {
           resolvedFilename = f;
           loaderContext.addDependency(resolvedFilename);

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -17,7 +17,7 @@ exports[`should provide a useful error message if the import could not be found 
 
 @import \\"not-existing\\";
 ^
-Can't resolve './not-existing.less' in '/test/fixtures/less'
+Can't resolve 'not-existing.less' in '/test/fixtures/less'
       in /test/fixtures/less/error-import-not-existing.less (line 1, column 0)"
 `;
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -122,6 +122,10 @@ test("should resolve all imports from the given paths using Less' resolver", asy
   });
 });
 
+test("should resolve all imports from the given paths using Webpack's resolver for less 3 style imports", async () => {
+  await compileAndCompare('import-paths', {});
+});
+
 test('should add all resolved imports as dependencies, including those from the Less resolver', async () => {
   const dependencies = [];
 


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

It is impossible to have code that both compiles in LESS and in Webpack due to the tilde requirement. This enables less-loader to fallback to the same import style as LESS 3.

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info
