### PR TITLE
Drop support for node < 6 and webpack < 4

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,19 +5,6 @@
       {
         "useBuiltIns": true,
         "targets": {
-          "node": "4.8"
-        },
-        "exclude": [
-          "transform-async-to-generator",
-          "transform-regenerator"
-        ]
-      }
-    ],
-    [
-      "env",
-      {
-        "useBuiltIns": true,
-        "targets": {
           "node": "6.9.0"
         },
         "exclude": [

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "bin": "",
   "main": "dist/cjs.js",
   "engines": {
-    "node": ">= 6.9.0 <7.0.0 || >= 8.9.0"
+    "node": ">= 6.9.0"
   },
   "scripts": {
     "start": "npm run build -- -w",
@@ -41,7 +41,7 @@
   ],
   "peerDependencies": {
     "less": "^2.3.1 || ^3.0.0",
-    "webpack": "^2.0.0 || ^3.0.0 || ^4.0.0"
+    "webpack": "^4.0.0"
   },
   "dependencies": {
     "@webpack-contrib/schema-utils": "^1.0.0-beta.0",


### PR DESCRIPTION
This PRs only removes some old left bits pointing to node < 6 and webpack < 4 versions.

/CC @evilebottnawi 