### PR TITLE
fix: webpack watching does not recover after broken less is fixed

### DIFF
--- a/src/processResult.js
+++ b/src/processResult.js
@@ -22,6 +22,9 @@ function processResult(loaderContext, resultPromise) {
         };
       },
       (lessError) => {
+        if (lessError.filename) {
+          loaderContext.addDependency(lessError.filename);
+        }
         throw formatLessError(lessError);
       }
     )


### PR DESCRIPTION
fix: #278 
