### PR TITLE
Support scope in module name

### DIFF
--- a/src/createWebpackLessPlugin.js
+++ b/src/createWebpackLessPlugin.js
@@ -18,7 +18,7 @@ const matchMalformedModuleFilename = /(~[^/\\]+)\.less$/;
 // This somewhat changed in Less 3.x. Now the file name comes without the
 // automatically added extension whereas the extension is passed in as `options.ext`.
 // So, if the file name matches this regexp, we simply ignore the proposed extension.
-const isModuleName = /^~(|@[a-z0-9-~][a-z0-9_.-~]*\/)[^/\\]+$/;
+const isModuleName = /^~(@[^/]+\/)?[^/\\]+$/;
 
 /**
  * Creates a Less plugin that uses webpack's resolving engine that is provided by the loaderContext.

--- a/src/createWebpackLessPlugin.js
+++ b/src/createWebpackLessPlugin.js
@@ -18,7 +18,7 @@ const matchMalformedModuleFilename = /(~[^/\\]+)\.less$/;
 // This somewhat changed in Less 3.x. Now the file name comes without the
 // automatically added extension whereas the extension is passed in as `options.ext`.
 // So, if the file name matches this regexp, we simply ignore the proposed extension.
-const isModuleName = /^~[^/\\]+$/;
+const isModuleName = /^~(|@[a-z0-9-~][a-z0-9_.-~]*\/)[^/\\]+$/;
 
 /**
  * Creates a Less plugin that uses webpack's resolving engine that is provided by the loaderContext.

--- a/test/fixtures/node_modules/@scope/some/css.css
+++ b/test/fixtures/node_modules/@scope/some/css.css
@@ -1,0 +1,3 @@
+.modules-dir-scope-some-module {
+	background: hotpink;
+}

--- a/test/fixtures/node_modules/@scope/some/module.less
+++ b/test/fixtures/node_modules/@scope/some/module.less
@@ -1,0 +1,3 @@
+.modules-dir-scope-some-module {
+	color: hotpink;
+}

--- a/test/fixtures/node_modules/@scope/some/package.json
+++ b/test/fixtures/node_modules/@scope/some/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@scope/some",
+  "main": "module.less"
+}

--- a/test/helpers/createSpec.js
+++ b/test/helpers/createSpec.js
@@ -20,9 +20,13 @@ const ignore = [
 ];
 const lessReplacements = [
   [/~some\//g, '../node_modules/some/'],
+  [/~@scope\/some\//g, '../node_modules/@scope/some/'],
   [/~(aliased-)?some"/g, '../node_modules/some/module.less"'],
 ];
-const cssReplacements = [[/\.\.\/node_modules\/some\//g, '~some/']];
+const cssReplacements = [
+  [/\.\.\/node_modules\/some\//g, '~some/'],
+  [/\.\.\/node_modules\/@scope\/some\//g, '~@scope/some/'],
+];
 // Maps test ids on cli arguments
 const lessOptions = {
   'source-map': [

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -62,6 +62,10 @@ test("should resolve all imports from node_modules using webpack's resolver", as
   await compileAndCompare('import-webpack');
 });
 
+test("should resolve all imports with npm scope from node_modules using webpack's resolver", async () => {
+  await compileAndCompare('import-webpack-scope');
+});
+
 test('should add all resolved imports as dependencies, including node_modules', async () => {
   const dependencies = [];
 


### PR DESCRIPTION
Support scope in module name. For example, "@fd/base-style" should be a valid module name, and can be imported by

```less
import "~@fd/base-style";
```

<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

Support scope in package name like `@fd/base-style`.

```less
import "~@fd/base-style";
```

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

No.

### Additional Info
