### PR TITLE
fix: fill less `options.filename` with `loaderContext.resourcePath` instead of `loaderContext.resource`

### DIFF
--- a/src/getOptions.js
+++ b/src/getOptions.js
@@ -16,7 +16,7 @@ function getOptions(loaderContext) {
   };
 
   // We need to set the filename because otherwise our WebpackFileManager will receive an undefined path for the entry
-  options.filename = loaderContext.resource;
+  options.filename = loaderContext.resourcePath;
 
   // When no paths are given, we use the webpack resolver
   if ('paths' in options === false) {


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Less options filename should be filled with a resourcePath without resourceQuery, in some case when a root less resource is requested with a query, filling filename with query may yield a resolve error when less core resolving other refered less resource
<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info
