### PR TITLE
chore: remove `pify` in favour of `util.promisify`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10873,7 +10873,8 @@
     "pify": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+      "dev": true
     },
     "pinkie": {
       "version": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
   "dependencies": {
     "clone": "^2.1.1",
     "loader-utils": "^1.4.0",
-    "pify": "^4.0.1",
     "schema-utils": "^2.6.5"
   },
   "devDependencies": {

--- a/src/createWebpackLessPlugin.js
+++ b/src/createWebpackLessPlugin.js
@@ -1,5 +1,6 @@
+import { promisify } from 'util';
+
 import less from 'less';
-import pify from 'pify';
 
 import { urlToRequest } from 'loader-utils';
 
@@ -32,8 +33,8 @@ const isModuleName = /^~[^/\\]+$/;
 function createWebpackLessPlugin(loaderContext) {
   const { fs } = loaderContext;
 
-  const loadModule = pify(loaderContext.loadModule.bind(loaderContext));
-  const readFile = pify(fs.readFile.bind(fs));
+  const loadModule = promisify(loaderContext.loadModule.bind(loaderContext));
+  const readFile = promisify(fs.readFile.bind(fs));
 
   const resolve = loaderContext.getResolve({
     mainFields: ['less', 'style', 'main', '...'],

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
+import { promisify } from 'util';
+
 import less from 'less';
-import pify from 'pify';
 
 import { getOptions } from 'loader-utils';
 import validateOptions from 'schema-utils';
@@ -8,7 +9,7 @@ import schema from './options.json';
 import processResult from './processResult';
 import getLessOptions from './getLessOptions';
 
-const render = pify(less.render.bind(less));
+const render = promisify(less.render.bind(less));
 
 function lessLoader(source) {
   const options = getOptions(this) || {};

--- a/test/helpers/readFixture.js
+++ b/test/helpers/readFixture.js
@@ -1,9 +1,8 @@
 const path = require('path');
 const fs = require('fs');
+const util = require('util');
 
-const pify = require('pify');
-
-const readFile = pify(fs.readFile);
+const readFile = util.promisify(fs.readFile);
 const testFolder = path.resolve(__dirname, '..');
 
 function readCssFixture(testId) {


### PR DESCRIPTION
This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [X] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Remove `pify` in favour of the native `promisify` function from the `util` library
