### PR TITLE
feat: allow a function to be used for `lessOptions`

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The `less-loader` requires [less](https://github.com/less/less.js) as [`peerDepe
 
 ### `lessOptions`
 
-Type: `Object`
+Type: `Object|Function`
 
 You can pass any Less specific options to the `less-loader` through the `lessOptions` property in the [loader options](https://webpack.js.org/configuration/module/#rule-options-rule-query). See the [Less documentation](http://lesscss.org/usage/#command-line-usage-options) for all available options in dash-case. Since we're passing these options to Less programmatically, you need to pass them in camelCase here:
 

--- a/src/getLessOptions.js
+++ b/src/getLessOptions.js
@@ -10,12 +10,20 @@ import createWebpackLessPlugin from './createWebpackLessPlugin';
  * @returns {Object}
  */
 function getLessOptions(loaderContext, loaderOptions) {
+  const options = clone(
+    loaderOptions.lessOptions
+      ? typeof loaderOptions.lessOptions === 'function'
+        ? loaderOptions.lessOptions(loaderContext) || {}
+        : loaderOptions.lessOptions
+      : {}
+  );
+
   const lessOptions = {
     plugins: [],
     relativeUrls: true,
     // We need to set the filename because otherwise our WebpackFileManager will receive an undefined path for the entry
     filename: loaderContext.resourcePath,
-    ...(loaderOptions.lessOptions ? clone(loaderOptions.lessOptions) : {}),
+    ...options,
   };
 
   if (typeof lessOptions.paths === 'undefined') {

--- a/src/options.json
+++ b/src/options.json
@@ -2,7 +2,7 @@
   "type": "object",
   "properties": {
     "lessOptions": {
-      "description": "Options to pass through to `less`. (https://github.com/webpack-contrib/less-loader#examples).",
+      "description": "Options to pass through to `less`. (https://github.com/webpack-contrib/less-loader#lessoptions).",
       "anyOf": [
         {
           "type": "object",
@@ -14,7 +14,7 @@
       ]
     },
     "sourceMap": {
-      "description": "Enables/Disables generation of source maps (https://github.com/webpack-contrib/less-loader#source-maps).",
+      "description": "Enables/Disables generation of source maps (https://github.com/webpack-contrib/less-loader#sourcemap).",
       "type": "boolean"
     }
   },

--- a/src/options.json
+++ b/src/options.json
@@ -3,8 +3,15 @@
   "properties": {
     "lessOptions": {
       "description": "Options to pass through to `less`. (https://github.com/webpack-contrib/less-loader#examples).",
-      "type": "object",
-      "additionalProperties": true
+      "anyOf": [
+        {
+          "type": "object",
+          "additionalProperties": true
+        },
+        {
+          "instanceof": "Function"
+        }
+      ]
     },
     "sourceMap": {
       "description": "Enables/Disables generation of source maps (https://github.com/webpack-contrib/less-loader#source-maps).",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -128,6 +128,16 @@ test("should resolve all imports from the given paths using Less' resolver", asy
   });
 });
 
+test('should allow a function to be passed through for `lessOptions`', async () => {
+  await compileAndCompare('import-paths', {
+    lessLoaderOptions: {
+      lessOptions: () => ({
+        paths: [__dirname, nodeModulesPath],
+      }),
+    },
+  });
+});
+
 test('should add all resolved imports as dependencies, including those from the Less resolver', async () => {
   const dependencies = [];
 


### PR DESCRIPTION
This PR contains a:

- [ ] **bugfix**
- [X] new **feature**
- [ ] **code refactor**
- [X] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Allow a function to be passed through for `lessOptions`, being called with the loader's context. Matches what `sass-loader` allows.
