### PR TITLE
Refactor - first resolve filename in less, then in webpack

### DIFF
--- a/src/createWebpackLessPlugin.js
+++ b/src/createWebpackLessPlugin.js
@@ -1,14 +1,10 @@
-import { promisify } from 'util';
-
 import less from 'less';
 
 import { urlToRequest } from 'loader-utils';
 
 /* eslint-disable class-methods-use-this */
 
-const stringifyLoader = require.resolve('./stringifyLoader.js');
 const trailingSlash = /[/\\]$/;
-const isLessCompatible = /\.(le|c)ss$/;
 
 // This somewhat changed in Less 3.x. Now the file name comes without the
 // automatically added extension whereas the extension is passed in as `options.ext`.
@@ -23,11 +19,6 @@ const isModuleName = /^~[^/\\]+$/;
  * @returns {LessPlugin}
  */
 function createWebpackLessPlugin(loaderContext) {
-  const { fs } = loaderContext;
-
-  const loadModule = promisify(loaderContext.loadModule.bind(loaderContext));
-  const readFile = promisify(fs.readFile.bind(fs));
-
   const resolve = loaderContext.getResolve({
     mainFields: ['less', 'style', 'main', '...'],
     mainFiles: ['_index', 'index', '...'],
@@ -40,7 +31,6 @@ function createWebpackLessPlugin(loaderContext) {
         return false;
       }
 
-      // Our WebpackFileManager handles all the files
       return true;
     }
 
@@ -82,49 +72,52 @@ function createWebpackLessPlugin(loaderContext) {
     }
 
     async loadFile(filename, currentDirectory, options, ...args) {
-      const url = this.getUrl(filename, options);
-
-      const moduleRequest = urlToRequest(
-        url,
-        url.charAt(0) === '/' ? '' : null
-      );
-
-      // Less is giving us trailing slashes, but the context should have no trailing slash
-      const context = currentDirectory.replace(trailingSlash, '');
-      let resolvedFilename;
-
       try {
-        resolvedFilename = await this.resolveRequests(context, [
-          moduleRequest,
-          url,
-        ]);
+        const resolvedData = await super.loadFile(
+          filename,
+          currentDirectory,
+          options,
+          ...args
+        );
+        loaderContext.addDependency(resolvedData.filename);
+
+        return resolvedData;
       } catch (error) {
-        loaderContext.emitError(error);
+        if (error.type !== 'File') {
+          loaderContext.emitError(error);
+        }
 
-        return super.loadFile(filename, currentDirectory, options, ...args);
+        const url = this.getUrl(filename, options);
+
+        const moduleRequest = urlToRequest(
+          url,
+          url.charAt(0) === '/' ? '' : null
+        );
+
+        // Less is giving us trailing slashes, but the context should have no trailing slash
+        const context = currentDirectory.replace(trailingSlash, '');
+
+        try {
+          const resolvedFilename = await this.resolveRequests(context, [
+            moduleRequest,
+            url,
+          ]);
+
+          const resolvedData = await super.loadFile(
+            resolvedFilename,
+            currentDirectory,
+            options,
+            ...args
+          );
+          loaderContext.addDependency(resolvedData.filename);
+
+          return resolvedData;
+        } catch (error) {
+          loaderContext.emitError(error);
+
+          return super.loadFile(filename, currentDirectory, options, ...args);
+        }
       }
-
-      loaderContext.addDependency(resolvedFilename);
-
-      if (isLessCompatible.test(resolvedFilename)) {
-        const fileBuffer = await readFile(resolvedFilename);
-        const contents = fileBuffer.toString('utf8');
-
-        return {
-          contents,
-          filename: resolvedFilename,
-        };
-      }
-
-      const loadedModule = await loadModule(
-        [stringifyLoader, resolvedFilename].join('!')
-      );
-      const contents = JSON.parse(loadedModule);
-
-      return {
-        contents,
-        filename: resolvedFilename,
-      };
     }
   }
 

--- a/test/fixtures/less/folder/some.file
+++ b/test/fixtures/less/folder/some.file
@@ -1,0 +1,3 @@
+.some-file {
+  background: hotpink;
+}


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

First resolve filename in less, then in webpack
Drop `loadModule`

### Breaking Changes

Yes

### Additional Info

No
