### PR TITLE
Add loader context in less plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,8 +476,7 @@ module.exports = {
 
 ### Plugins
 
-In order to use [plugins](http://lesscss.org/usage/#plugins), simply set the
-`plugins` option like this:
+In order to use [plugins](http://lesscss.org/usage/#plugins), simply set the `plugins` option like this:
 
 ```js
 // webpack.config.js
@@ -496,6 +495,20 @@ module.exports = {
       },
     },
   ...
+};
+```
+
+> ℹ️ Access to the [loader context](https://webpack.js.org/api/loaders/#the-loader-context) inside the custom plugin can be done using the `less.webpackLoaderContext` property.
+
+```js
+module.exports = {
+  install: function (less, pluginManager, functions) {
+    functions.add('pi', function () {
+      // Loader context is available in `less.webpackLoaderContext`
+
+      return Math.PI;
+    });
+  },
 };
 ```
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -166,6 +166,13 @@ function getLessOptions(loaderContext, loaderOptions) {
     lessOptions.plugins.unshift(createWebpackLessPlugin(loaderContext));
   }
 
+  lessOptions.plugins.unshift({
+    install(lessProcessor) {
+      // eslint-disable-next-line no-param-reassign
+      lessProcessor.webpackLoaderContext = loaderContext;
+    },
+  });
+
   const useSourceMap =
     typeof loaderOptions.sourceMap === 'boolean'
       ? loaderOptions.sourceMap

--- a/test/__snapshots__/loader.test.js.snap
+++ b/test/__snapshots__/loader.test.js.snap
@@ -511,6 +511,17 @@ exports[`loader should watch imports correctly: errors 1`] = `Array []`;
 
 exports[`loader should watch imports correctly: warnings 1`] = `Array []`;
 
+exports[`loader should work loaderContext in less plugins: css 1`] = `
+".webpackLoaderContext {
+  isDefined: true;
+}
+"
+`;
+
+exports[`loader should work loaderContext in less plugins: errors 1`] = `Array []`;
+
+exports[`loader should work loaderContext in less plugins: warnings 1`] = `Array []`;
+
 exports[`loader should work third-party plugins as fileLoader: css 1`] = `
 ".file-loader {
   background: coral;

--- a/test/fixtures/basic-plugins.less
+++ b/test/fixtures/basic-plugins.less
@@ -1,0 +1,5 @@
+@plugin "plugin-1";
+
+.webpackLoaderContext {
+  isDefined: run();
+}

--- a/test/fixtures/plugin-1.js
+++ b/test/fixtures/plugin-1.js
@@ -1,0 +1,11 @@
+registerPlugin({
+  install: function(less, pluginManager, functions) {
+    functions.add('run', function() {
+      if (typeof less.webpackLoaderContext !== 'undefined') {
+        return 'true';
+      }
+
+      return 'false';
+    });
+  }
+})

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -727,4 +727,50 @@ describe('loader', () => {
     expect(getWarnings(stats)).toMatchSnapshot('warnings');
     expect(getErrors(stats)).toMatchSnapshot('errors');
   });
+
+  it('should work loaderContext in less plugins', async () => {
+    let contextInClass;
+    let contextInObject;
+
+    // eslint-disable-next-line global-require
+    class Plugin extends require('less').FileManager {
+      constructor(less) {
+        super();
+
+        if (typeof less.webpackLoaderContext !== 'undefined') {
+          contextInClass = true;
+        }
+      }
+    }
+
+    class CustomClassPlugin {
+      // eslint-disable-next-line class-methods-use-this
+      install(less, pluginManager) {
+        pluginManager.addFileManager(new Plugin(less));
+      }
+    }
+
+    const customObjectPlugin = {
+      install(less) {
+        if (typeof less.webpackLoaderContext !== 'undefined') {
+          contextInObject = true;
+        }
+      },
+    };
+
+    const testId = './basic-plugins.less';
+    const compiler = getCompiler(testId, {
+      lessOptions: {
+        plugins: [new CustomClassPlugin(), customObjectPlugin],
+      },
+    });
+    const stats = await compile(compiler);
+    const codeFromBundle = getCodeFromBundle(stats, compiler);
+
+    expect(contextInClass).toBe(true);
+    expect(contextInObject).toBe(true);
+    expect(codeFromBundle.css).toMatchSnapshot('css');
+    expect(getWarnings(stats)).toMatchSnapshot('warnings');
+    expect(getErrors(stats)).toMatchSnapshot('errors');
+  });
 });


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [x] **metadata update**

### Motivation / Use-Case

Add loader context in less plugins
Loader context is available in `less.webpackLoaderContext`

### Breaking Changes

No

### Additional Info

No
