### PR TITLE
fix: do not emit emit deprecation warning while call deprecation plugin itself

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ npm-debug.log
 /node_modules
 /coverage
 .idea
+.vscode
+.history
 .nyc_output
 npm-debug.log*
 yarn-debug.log*

--- a/src/utils.js
+++ b/src/utils.js
@@ -193,7 +193,7 @@ function getLessOptions(loaderContext, loaderOptions) {
       pluginManager.webpackLoaderContext = loaderContext;
 
       // Todo remove in next major release
-      if (typeof lessProcessor.webpackLoaderContext === "undefined") {
+      if (!("webpackLoaderContext" in lessProcessor)) {
         Object.defineProperty(lessProcessor, "webpackLoaderContext", {
           configurable: true,
 


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Deprecation warning 
```
DeprecationWarning: less.webpackLoaderContext is deprecated and will be removed in next major release. Instead use pluginManager.webpackLoaderContext (https://webpack.js.org/loaders/less-loader/#plugins)
```

will be shown independently by user settings by the less-loader itself

This pr changes the way the deprecation warning plugin checks for already added webpackLoaderContext in lessProcessor
<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info
