### PR TITLE
feat: add option implementation string support

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ And run `webpack` via your preferred method.
 |  **[`additionalData`](#additionalData)**  | `{String\|Function}` |       `undefined`        | Prepends/Appends `Less` code to the actual entry file. |
 |       **[`sourceMap`](#sourcemap)**       |     `{Boolean}`      |    `compiler.devtool`    | Enables/Disables generation of source maps.            |
 | **[`webpackImporter`](#webpackimporter)** |     `{Boolean}`      |          `true`          | Enables/Disables the default Webpack importer.         |
-|  **[`implementation`](#implementation)**  |      `{Object}`      |          `less`          | Setup Less implementation to use.                      |
+|  **[`implementation`](#implementation)**  |  `{Object\|String}`  |          `less`          | Setup Less implementation to use.                      |
 
 ### `lessOptions`
 
@@ -316,7 +316,7 @@ module.exports = {
 
 ### `implementation`
 
-Type: `Object`
+Type: `Object` | `String`
 
 > ⚠ less-loader compatible with Less 3 and 4 versions
 
@@ -338,6 +338,7 @@ module.exports = {
           {
             loader: "less-loader",
             options: {
+              // implementation : require.resolve('less')
               implementation: require("less"),
             },
           },

--- a/src/index.js
+++ b/src/index.js
@@ -35,7 +35,13 @@ async function lessLoader(source) {
   let result;
 
   try {
-    result = await (options.implementation || less).render(data, lessOptions);
+    const impl = options.implementation;
+    result =
+      await // eslint-disable-next-line global-require,import/no-dynamic-require
+      ((typeof impl === "string" ? require(impl) : impl) || less).render(
+        data,
+        lessOptions
+      );
   } catch (error) {
     if (error.filename) {
       // `less` returns forward slashes on windows when `webpack` resolver return an absolute windows path in `WebpackFileManager`

--- a/src/options.json
+++ b/src/options.json
@@ -35,7 +35,14 @@
     },
     "implementation": {
       "description": "The implementation of the `Less` to be used (https://github.com/webpack-contrib/less-loader#implementation).",
-      "type": "object"
+      "anyOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string"
+        }
+      ]
     }
   },
   "additionalProperties": false

--- a/test/__snapshots__/implementation.test.js.snap
+++ b/test/__snapshots__/implementation.test.js.snap
@@ -1,5 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`"implementation" option should work with path string: css 1`] = `
+".box {
+  color: #fe33ac;
+  border-color: #fdcdea;
+  background: url(box.png);
+}
+.box div {
+  -webkit-box-shadow: 0 0 5px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 0 5px rgba(0, 0, 0, 0.3);
+}
+"
+`;
+
+exports[`"implementation" option should work with path string: errors 1`] = `Array []`;
+
+exports[`"implementation" option should work with path string: warnings 1`] = `Array []`;
+
 exports[`"implementation" option should work: css 1`] = `
 ".box {
   color: #fe33ac;

--- a/test/__snapshots__/validate-options.test.js.snap
+++ b/test/__snapshots__/validate-options.test.js.snap
@@ -60,25 +60,37 @@ exports[`validate options should throw an error on the "additionalData" option w
     * options.additionalData should be an instance of function."
 `;
 
-exports[`validate options should throw an error on the "implementation" option with "false" value 1`] = `
+exports[`validate options should throw an error on the "implementation" option with "1" value 1`] = `
 "Invalid options object. Less Loader has been initialized using an options object that does not match the API schema.
- - options.implementation should be an object:
-   object { … }
-   -> The implementation of the \`Less\` to be used (https://github.com/webpack-contrib/less-loader#implementation)."
+ - options.implementation should be one of these:
+   object { … } | string
+   -> The implementation of the \`Less\` to be used (https://github.com/webpack-contrib/less-loader#implementation).
+   Details:
+    * options.implementation should be an object:
+      object { … }
+    * options.implementation should be a string."
 `;
 
-exports[`validate options should throw an error on the "implementation" option with "string" value 1`] = `
+exports[`validate options should throw an error on the "implementation" option with "false" value 1`] = `
 "Invalid options object. Less Loader has been initialized using an options object that does not match the API schema.
- - options.implementation should be an object:
-   object { … }
-   -> The implementation of the \`Less\` to be used (https://github.com/webpack-contrib/less-loader#implementation)."
+ - options.implementation should be one of these:
+   object { … } | string
+   -> The implementation of the \`Less\` to be used (https://github.com/webpack-contrib/less-loader#implementation).
+   Details:
+    * options.implementation should be an object:
+      object { … }
+    * options.implementation should be a string."
 `;
 
 exports[`validate options should throw an error on the "implementation" option with "true" value 1`] = `
 "Invalid options object. Less Loader has been initialized using an options object that does not match the API schema.
- - options.implementation should be an object:
-   object { … }
-   -> The implementation of the \`Less\` to be used (https://github.com/webpack-contrib/less-loader#implementation)."
+ - options.implementation should be one of these:
+   object { … } | string
+   -> The implementation of the \`Less\` to be used (https://github.com/webpack-contrib/less-loader#implementation).
+   Details:
+    * options.implementation should be an object:
+      object { … }
+    * options.implementation should be a string."
 `;
 
 exports[`validate options should throw an error on the "lessOptions" option with "[]" value 1`] = `

--- a/test/implementation.test.js
+++ b/test/implementation.test.js
@@ -23,4 +23,19 @@ describe('"implementation" option', () => {
     expect(getWarnings(stats)).toMatchSnapshot("warnings");
     expect(getErrors(stats)).toMatchSnapshot("errors");
   });
+
+  it("should work with path string", async () => {
+    const testId = "./basic.less";
+    const compiler = getCompiler(testId, {
+      implementation: "less",
+    });
+    const stats = await compile(compiler);
+    const codeFromBundle = getCodeFromBundle(stats, compiler);
+    const codeFromLess = await getCodeFromLess(testId);
+
+    expect(codeFromBundle.css).toBe(codeFromLess.css);
+    expect(codeFromBundle.css).toMatchSnapshot("css");
+    expect(getWarnings(stats)).toMatchSnapshot("warnings");
+    expect(getErrors(stats)).toMatchSnapshot("errors");
+  });
 });

--- a/test/validate-options.test.js
+++ b/test/validate-options.test.js
@@ -27,8 +27,8 @@ describe("validate options", () => {
     },
     implementation: {
       // eslint-disable-next-line global-require
-      success: [require("less")],
-      failure: [true, false, "string"],
+      success: [require("less"), "less"],
+      failure: [true, false, 1],
     },
     unknown: {
       success: [],


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation 

If `webpack` is running in child_process and you want to pass `less` instance from the main process or the current project.

In my story, I made a command-line based compilation tool that uses `webpack` as one of the compilation engines and runs in a child process. I want to use the less version of the current project as a compilation tool. At this point, since webpack is running in the child process, the passed configuration will be serialized into JSON and passed to the child process, child process which will then parse it into an `object`.  `implementation: require('less')` won't work. 

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

 
