### PR TITLE
fix: only call `addDependency` on absolute path to avoid Webpack 5 wa…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -69,7 +69,12 @@ async function lessLoader(source) {
 
     // `less` return forward slashes on windows when `webpack` resolver return an absolute windows path in `WebpackFileManager`
     // Ref: https://github.com/webpack-contrib/less-loader/issues/357
-    this.addDependency(path.normalize(item));
+    const normalizedItem = path.normalize(item);
+
+    // Custom `importer` can return only `contents` so item will be relative
+    if (path.isAbsolute(normalizedItem)) {
+      this.addDependency(normalizedItem);
+    }
   });
 
   let map =


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

With Webpack v5, we get this below warning when using some package like `less-glob-plugin` due custom importer format (here glob) and Less is not able to reliably resolve those source strings to absolute paths.

```
Invalid dependencies have been reported by plugins or loaders for this module. All reported dependencies need to be absolute paths.
Invalid dependencies may lead to broken watching and caching.
As best effort we try to convert all invalid values to absolute paths and converting globs into context dependencies, but this is deprecated behavior.
Loaders: Pass absolute paths to this.addDependency (existing files), this.addMissingDependency (not existing files), and this.addContextDependency (directories).
Plugins: Pass absolute paths to fileDependencies (existing files), missingDependencies (not existing files), and contextDependencies (directories).
Globs: They are not supported. Pass absolute path to the directory as context dependencies.
The following invalid values have been reported:
 * "src/components/**/*.less"
 @ ./config/theme.less 8:6-168 22:17-24 26:7-21 58:25-39 59:36-47 59:50-64 63:6-73:7 64:54-65 64:68-82 70:42-53 70:56-70 72:21-28 83:0-138 83:0-138 84:22-29 84:33-47 84:50-64 61:4-74:5
 @ ./config/bundle.js 2:0-23
```

### Breaking Changes

No

### Additional Info

No