### PR TITLE
fix less-loader example: replace `loader` with `use`

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ module.exports = {
     rules: [
       {
         test: /\.less$/i,
-        loader: [
+        use: [
           // compiles Less to CSS
           "style-loader",
           "css-loader",


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [x] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Currently the example shows `loader` instead of `use` which will not work with Webpack 5

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info
