### PR TITLE
feat: add onlyWebpackImporter option

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,45 @@ module.exports = {
 };
 ```
 
+### `onlyWebpackImporter`
+
+Type:
+
+```ts
+type onlyWebpackImporter = boolean;
+```
+
+Default: `true`
+
+Enables/Disables the only use `webpack` importer.
+
+This can improve performance in some cases. Use it with caution because aliases and `@import` from [`node_modules`](https://webpack.js.org/configuration/resolve/#resolvemodules) will not work.
+
+**webpack.config.js**
+
+```js
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.less$/i,
+        use: [
+          "style-loader",
+          "css-loader",
+          {
+            loader: "less-loader",
+            options: {
+              webpackImporter: true,
+              onlyWebpackImporter: true,
+            },
+          },
+        ],
+      },
+    ],
+  },
+};
+```
+
 ### `implementation`
 
 Type:

--- a/src/utils.js
+++ b/src/utils.js
@@ -30,6 +30,7 @@ const MODULE_REQUEST_REGEX = /^[^?]*~/;
  * @returns {LessPlugin}
  */
 function createWebpackLessPlugin(loaderContext, implementation) {
+  const lessOptions = loaderContext.getOptions();
   const resolve = loaderContext.getResolve({
     dependencyType: "less",
     conditionNames: ["less", "style", "..."],
@@ -105,7 +106,7 @@ function createWebpackLessPlugin(loaderContext, implementation) {
       let result;
 
       try {
-        if (IS_SPECIAL_MODULE_IMPORT.test(filename)) {
+        if (IS_SPECIAL_MODULE_IMPORT.test(filename) || lessOptions.onlyWebpackImporter) {
           const error = new Error();
 
           error.type = "Next";


### PR DESCRIPTION
This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

When using the `resolve.extensionAlias` property in `webpack` or `rspack`, the built-in importer of less-loader would cause this property to become ineffective. Therefore, we've added an `onlyWebpackImporter` option to enable this capability.

### Breaking Changes

No breaking Changes

### Additional Info
No additional info
