### PR TITLE
feat: enable lessLogAsWarnOrErr by default

### DIFF
--- a/.changeset/less-log-as-warn-or-err-default.md
+++ b/.changeset/less-log-as-warn-or-err-default.md
@@ -1,0 +1,5 @@
+---
+"less-loader": major
+---
+
+`lessLogAsWarnOrErr` now defaults to `true`. Less warnings and errors are emitted as webpack warnings and errors by default. Set the option to `false` to restore the previous behavior of logging silently.

--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ Type:
 type lessLogAsWarnOrErr = boolean;
 ```
 
-Default: `false`
+Default: `true`
 
 `Less` warnings and errors will be treated as webpack warnings and errors, instead of being logged silently.
 
@@ -441,7 +441,7 @@ div {
 }
 ```
 
-If `lessLogAsWarnOrErr` is set to `false` it will be just a log and webpack will compile successfully, but if you set this option to `true` webpack will compile fail with a warning(or error), and can break the build if configured accordingly.
+If `lessLogAsWarnOrErr` is set to `false` it will be just a log and webpack will compile successfully, but if you leave the default value (or set this option to `true`) webpack will compile fail with a warning(or error), and can break the build if configured accordingly.
 
 **webpack.config.js**
 

--- a/src/index.js
+++ b/src/index.js
@@ -72,11 +72,11 @@ async function lessLoader(content) {
 
   const logger = this.getLogger("less-loader");
   const loaderContext = this;
+  const lessLogAsWarnOrErr = options.lessLogAsWarnOrErr !== false;
   const loggerListener = {
     /** @param {string} message message */
     error(message) {
-      // TODO enable by default in the next major release
-      if (options.lessLogAsWarnOrErr) {
+      if (lessLogAsWarnOrErr) {
         loaderContext.emitError(new Error(message));
       } else {
         logger.error(message);
@@ -84,8 +84,7 @@ async function lessLoader(content) {
     },
     /** @param {string} message message */
     warn(message) {
-      // TODO enable by default in the next major release
-      if (options.lessLogAsWarnOrErr) {
+      if (lessLogAsWarnOrErr) {
         loaderContext.emitWarning(new Error(message));
       } else {
         logger.warn(message);

--- a/test/__snapshots__/loader.test.js.snap
+++ b/test/__snapshots__/loader.test.js.snap
@@ -475,7 +475,9 @@ exports[`loader > should work and have loaderContext in less plugins 1`] = `
 `;
 
 exports[`loader > should work and have loaderContext in less plugins 2`] = `
-[]
+[
+  "ModuleWarning: Module Warning (from \`replaced original path\`):\\nDEPRECATED WARNING: The @plugin directive is deprecated and will be replaced in Less 5.x. Use --plugin CLI option or the programmatic plugin API instead. in /test/fixtures/basic-plugins-2.less on line 1, column 1:"
+]
 `;
 
 exports[`loader > should work and have loaderContext in less plugins 3`] = `
@@ -490,12 +492,6 @@ exports[`loader > should work and logging 2`] = `
 [
   [
     {
-      "type": "warn",
-      "args": [
-        "WARNING: extend ' .inline' has no matches"
-      ]
-    },
-    {
       "type": "log",
       "args": [
         "The file undefined was skipped because it was not found and the import was marked optional."
@@ -506,7 +502,9 @@ exports[`loader > should work and logging 2`] = `
 `;
 
 exports[`loader > should work and logging 3`] = `
-[]
+[
+  "ModuleWarning: Module Warning (from \`replaced original path\`):\\nWARNING: extend ' .inline' has no matches"
+]
 `;
 
 exports[`loader > should work and logging 4`] = `


### PR DESCRIPTION
Resolves the TODOs that deferred this to the next major release. Less
warnings and errors are now surfaced as webpack warnings and errors
unless `lessLogAsWarnOrErr` is explicitly set to `false`.

https://claude.ai/code/session_019hqB5h8BUwy6hazGuDfjYR